### PR TITLE
Added a submenu to update the W3C validation manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ the current issues.
 
 Issues/Updates
 =====
+[8/28/2014] Added a submenu (under "Edit") to update the W3C validation (fixed bug when connection lost).
+
 [5/19/2014] Removed an annoying console message.
 
 [4/15/2014] Requires Brackets Sprint 38. Supports sexy new async linting.

--- a/main.js
+++ b/main.js
@@ -3,27 +3,34 @@
 
 define(function (require, exports, module) {
 	'use strict';
-	
-	var CodeInspection			= brackets.getModule("language/CodeInspection"),
-		AppInit                 = brackets.getModule("utils/AppInit");
 
+	var CodeInspection			= brackets.getModule("language/CodeInspection"),
+		AppInit					= brackets.getModule("utils/AppInit"),
+		Menus					= brackets.getModule("command/Menus"),
+		CommandManager			= brackets.getModule("command/CommandManager"),
+		DocumentManager			= brackets.getModule("document/DocumentManager");
+	
+	var COMMAND_ID	= "w3cvalidator_refresh",
+		PROVIDER_ID	= "W3CValidation";
+	
+	
 	require('w3cvalidator');
 	
 	function _handleValidation(text, fullPath) {
 		var response = new $.Deferred();
 		var result = {errors:[]};
-			
+		
 		W3CValidator.validate(text, function (res) {
 			var messages = res.messages;
 			
 			if (messages.length) {
-									
 				messages.forEach(function (item) {
 					//console.log('W3CValidation messsage ',item);
 					var type = CodeInspection.Type.ERROR;
-					if (item.type === "warning") {
-                        type = CodeInspection.Type.WARNING;
-                    }
+					
+					if (item.type === "warning")
+						type = CodeInspection.Type.WARNING;
+					
 					result.errors.push({
 						pos: {line:item.lastLine-1, ch:0},
 						message:item.message,
@@ -31,26 +38,32 @@ define(function (require, exports, module) {
 					});
 					
 				});
-		  
 			}
 
-			response.resolve(result);        
-			
-		}); 
-
-		return response.promise();
-
-	}
-		
-	AppInit.appReady(function () {
-
-
-		CodeInspection.register("html", {
-			name: "W3CValidation",
-			scanFileAsync: _handleValidation
+			response.resolve(result);
 		});
 		
+		return response.promise();
+	}
+	
+	function _refreshValidation() {
+		var currentDoc = DocumentManager.getCurrentDocument();
+		currentDoc.notifySaved();
+	}
+	
+	AppInit.appReady(function () {
+		CodeInspection.register("html", {
+			//name: "W3CValidation",
+			name: PROVIDER_ID,
+			scanFileAsync: _handleValidation
+		});
 	});
 	
 	
+	// Command
+	CommandManager.register("Refresh W3C validation", COMMAND_ID, _refreshValidation);
+	
+	// Menu
+	var editMenu = Menus.getMenu(Menus.AppMenuBar.EDIT_MENU);
+	editMenu.addMenuItem(COMMAND_ID);
 });

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "homepage": "https://github.com/cfjedimaster/brackets-w3cvalidation",
     "keywords":["lint","linting","linter"],
     "categories":"linting",
-    "version": "2.1.1",
+    "version": "2.1.2",
     "author": "Raymond Camden <raymondcamden@gmail.com> (http://www.raymondcamden.com)",
     "license": "MIT",
     "engines": {

--- a/w3cvalidator.js
+++ b/w3cvalidator.js
@@ -1,18 +1,14 @@
 var W3CValidator = (function() {
-    
-    var W3CURL = "http://validator.w3.org/check";
-        
-    return {
-     
-        validate:function(str,cb) {
-            $.post(W3CURL, {
-                "fragment":str,
-                "output":"json"
-            }, function(res,code) {
-             cb(res);
-            });
-        }
-        
-    };
-    
+	var W3CURL = "http://validator.w3.org/check";
+	
+	return {
+		validate:function(str,cb) {
+			$.post(W3CURL, {
+				"fragment":str,
+				"output":"json"
+			}, function(res,code) {
+				cb(res);
+			});
+		}
+	};
 }());


### PR DESCRIPTION
This patch fix a bug when the internet connection is lost (W3C timeout).
It just triggers a save event to start the W3C check.

NOTE: I've also properly formatted the code.
